### PR TITLE
Add Admin Role Guard and Implement User Fetching Endpoints

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,10 +1,10 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto, PartialUserDto } from 'src/users/dto';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) { }
 
   @Post('/signup')
   signup(@Body() createUserDto: CreateUserDto) {
@@ -15,4 +15,6 @@ export class AuthController {
   async login(@Body() user: PartialUserDto) {
     return this.authService.login(user.email!, user.password!);
   }
+
+
 }

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -9,7 +9,7 @@ import { AuthService } from '../auth.service';
 
 @Injectable()
 export class JwtGuard implements CanActivate {
-  constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) { }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     try {

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -8,8 +8,8 @@ import {
 import { AuthService } from '../auth.service';
 
 @Injectable()
-export class JwtGuard implements CanActivate {
-  constructor(private readonly authService: AuthService) { }
+export class AuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     try {

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,19 +1,41 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../../users/entities';
 import { ROLES_KEY } from '../decorators';
+import { AuthService } from '../auth.service';
+import { Request } from 'express';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(
+    private reflector: Reflector,
+    private authService: AuthService, // Inject AuthService to validate the token
+  ) { }
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
     if (!requiredRoles) return true;
-    const { user } = context.switchToHttp().getRequest();
-    return requiredRoles.some(role => user?.role?.includes(role));
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = request.headers['authorization']?.split(' ')[1];
+
+    if (!token) throw new UnauthorizedException('No token provided');
+
+    let user;
+    try {
+      user = this.authService.validateToken(token);
+    } catch (e) {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    const hasRole = requiredRoles.some((role) => user.role.includes(role));
+    if (!hasRole) {
+      throw new UnauthorizedException('You do not have the required role');
+    }
+
+    return true;
   }
 }

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,41 +1,19 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '../../users/entities';
 import { ROLES_KEY } from '../decorators';
-import { AuthService } from '../auth.service';
-import { Request } from 'express';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(
-    private reflector: Reflector,
-    private authService: AuthService, // Inject AuthService to validate the token
-  ) { }
+  constructor(private reflector: Reflector) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  canActivate(context: ExecutionContext): boolean {
     const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
     if (!requiredRoles) return true;
-
-    const request = context.switchToHttp().getRequest<Request>();
-    const token = request.headers['authorization']?.split(' ')[1];
-
-    if (!token) throw new UnauthorizedException('No token provided');
-
-    let user;
-    try {
-      user = this.authService.validateToken(token);
-    } catch (e) {
-      throw new UnauthorizedException('Invalid token');
-    }
-
-    const hasRole = requiredRoles.some((role) => user.role.includes(role));
-    if (!hasRole) {
-      throw new UnauthorizedException('You do not have the required role');
-    }
-
-    return true;
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => user?.role?.includes(role));
   }
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,12 +1,5 @@
-import {
-  IsNotEmpty,
-  IsString,
-  IsEmail,
-  IsEnum,
-  IsBoolean,
-} from 'class-validator';
+import { IsNotEmpty, IsString, IsEmail, IsEnum } from 'class-validator';
 import { Role } from '../entities';
-import { Exclude } from 'class-transformer';
 
 export class CreateUserDto {
   @IsNotEmpty()
@@ -25,7 +18,6 @@ export class CreateUserDto {
   @IsEmail()
   email: string;
 
-  @Exclude()
   @IsNotEmpty()
   @IsString()
   password: string;

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -9,6 +9,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm'
   ;
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class User {
@@ -27,6 +28,7 @@ export class User {
   @Column()
   email: string;
 
+  @Exclude()
   @Column()
   password: string;
 

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -6,7 +6,8 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
-} from 'typeorm';
+} from 'typeorm'
+  ;
 
 @Entity()
 export class User {

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -12,7 +12,7 @@ import {
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('uuid')
-  id: UUID;
+  id: string;
 
   @Column()
   rut: string;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -31,9 +31,11 @@ export class UsersController {
     return this.usersService.findAll();
   }
 
-  @Get(':UUID')
-  findOne(@Param('UUID') UUID: string) {
-    return this.usersService.findOne(UUID);
+  @Get('/country')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  async findByCountry(@Query('country') country: string) {
+    return this.usersService.findByCountry(country);
   }
 
   @Get('/query')
@@ -43,12 +45,10 @@ export class UsersController {
     return this.usersService.findByQuery({ name, email });
   }
 
-  // @UseGuards(RolesGuard)
-  // @Roles(Role.ADMIN)
-  @Get('/country')
-  findByCountry(@Query('country') country: string) {
-    console
-    return this.usersService.findByCountry(country);
+
+  @Get(':UUID')
+  findOne(@Param('UUID') UUID: string) {
+    return this.usersService.findOne(UUID);
   }
 
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -7,16 +7,16 @@ import {
   Param,
   Delete,
   Query,
-  UseGuards
+  UseGuards,
   ClassSerializerInterceptor,
   UseInterceptors,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto, UpdateUserDto } from './dto';
-import { UUID } from 'crypto';
 import { RolesGuard } from '../auth/guards';
 import { Roles } from 'src/auth/decorators';
 import { Role } from './entities';
+import { UUID } from 'node:crypto';
 
 @Controller('users')
 export class UsersController {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -27,30 +27,14 @@ export class UsersController {
   @Get()
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
-  findAll() {
-    return this.usersService.findAll();
+  findAll(@Query('country') country?: string, @Query('name') name?: string, @Query('email',) email?: string) {
+    return this.usersService.findAll(country, name, email);
   }
-
-  @Get('/country')
-  @UseGuards(RolesGuard)
-  @Roles(Role.ADMIN)
-  async findByCountry(@Query('country') country: string) {
-    return this.usersService.findByCountry(country);
-  }
-
-  @Get('/query')
-  @UseGuards(RolesGuard)
-  @Roles(Role.ADMIN)
-  findByQuery(@Query('name') name: string, @Query('email') email: string) {
-    return this.usersService.findByQuery({ name, email });
-  }
-
 
   @Get(':UUID')
   findOne(@Param('UUID') UUID: string) {
     return this.usersService.findOne(UUID);
   }
-
 
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateUserDto: PartialUserDto) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto, UpdateUserDto } from './dto';
-import { RolesGuard } from '../auth/guards';
+import { AuthGuard, RolesGuard } from '../auth/guards';
 import { Roles } from 'src/auth/decorators';
 import { Role } from './entities';
 import { UUID } from 'node:crypto';
@@ -24,12 +24,13 @@ export class UsersController {
 
   @Post()
   create(@Body() createUserDto: CreateUserDto) {
+
     return this.usersService.create(createUserDto);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
   @Get()
-  @UseGuards(RolesGuard)
+  @UseGuards(AuthGuard, RolesGuard)
   @Roles(Role.ADMIN)
   findAll(@Query('country') country?: string, @Query('name') name?: string, @Query('email',) email?: string) {
     return this.usersService.findAll(country, name, email);
@@ -37,17 +38,23 @@ export class UsersController {
 
   @UseInterceptors(ClassSerializerInterceptor)
   @Get(':id')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
   findOne(@Param('id') id: UUID) {
     return this.usersService.findOne(id);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)
   @Patch(':id')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
   update(@Param('id') id: UUID, @Body() updateUserDto: UpdateUserDto) {
     return this.usersService.update(id, updateUserDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
   remove(@Param('id') id: UUID) {
     return this.usersService.remove(id);
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -6,13 +6,14 @@ import {
   Patch,
   Param,
   Delete,
+  Query
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto, PartialUserDto } from './dto';
 
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(private readonly usersService: UsersService) { }
 
   @Post()
   create(@Body() createUserDto: CreateUserDto) {
@@ -24,10 +25,21 @@ export class UsersController {
     return this.usersService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.usersService.findOne(+id);
+  // @Get(':UUID')
+  // findOne(@Param('UUID') UUID: string) {
+  //   return this.usersService.findOne(UUID);
+  // }
+
+  @Get('/query')
+  findByQuery(@Query('name') name: string, @Query('email') email: string) {
+    return this.usersService.findByQuery({ name, email });
   }
+
+  @Get('/country')
+  findByCountry(@Query('country') country: string) {
+    return this.usersService.findByCountry(country);
+  }
+
 
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateUserDto: PartialUserDto) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -6,10 +6,14 @@ import {
   Patch,
   Param,
   Delete,
-  Query
+  Query,
+  UseGuards
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto, PartialUserDto } from './dto';
+import { RolesGuard } from '../auth/guards';
+import { Roles } from 'src/auth/decorators';
+import { Role } from './entities';
 
 @Controller('users')
 export class UsersController {
@@ -21,22 +25,29 @@ export class UsersController {
   }
 
   @Get()
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
   findAll() {
     return this.usersService.findAll();
   }
 
-  // @Get(':UUID')
-  // findOne(@Param('UUID') UUID: string) {
-  //   return this.usersService.findOne(UUID);
-  // }
+  @Get(':UUID')
+  findOne(@Param('UUID') UUID: string) {
+    return this.usersService.findOne(UUID);
+  }
 
   @Get('/query')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
   findByQuery(@Query('name') name: string, @Query('email') email: string) {
     return this.usersService.findByQuery({ name, email });
   }
 
+  // @UseGuards(RolesGuard)
+  // @Roles(Role.ADMIN)
   @Get('/country')
   findByCountry(@Query('country') country: string) {
+    console
     return this.usersService.findByCountry(country);
   }
 

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -12,4 +12,4 @@ import { JwtService } from '@nestjs/jwt';
   controllers: [UsersController],
   providers: [UsersService, AuthService, JwtService]
 })
-export class UsersModule {}
+export class UsersModule { }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -15,7 +15,7 @@ export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
-  ) {}
+  ) { }
 
   private readonly rounds: number = parseInt(process.env.SALT_ROUNDS!);
 
@@ -34,12 +34,51 @@ export class UsersService {
     }
   }
 
-  async findAll() {
-    return `This action returns all users`;
+  async findAll() {  //obtener todos los usuarios
+    const users = await this.usersRepository.find();
+    users.forEach((user) => delete user.password);
+    return users;
   }
 
-  async findOne(id: number) {
-    return `This action returns a #${id} user`;
+  // async findOne(UUID: string ) {
+  //   try {
+  //     const user = await this.usersRepository.findOneBy({ id: UUID });
+  //     if (!user) throw new NotFoundException('User not found');
+  //     delete user.password;
+  //     return user;
+  //   } catch (err) {
+  //     throw new InternalServerErrorException(err.message);
+  //   }
+  // }
+
+
+  async findByQuery(query: { name?: string; email?: string }) {
+    try {
+      const queryBuilder = this.usersRepository.createQueryBuilder('user');
+
+      if (query.name) {
+        queryBuilder.orWhere('user.name LIKE :name', { name: `%${query.name}%` });
+      }
+      if (query.email) {
+        queryBuilder.orWhere('user.email LIKE :email', { email: `%${query.email}%` });
+      }
+
+      const users = await queryBuilder.getMany();
+      users.forEach(user => delete user.password);
+      return users;
+    } catch (err) {
+      throw new InternalServerErrorException(err.message);
+    }
+  }
+
+  async findByCountry(country: string) {
+    try {
+      const users = await this.usersRepository.find({ where: { country } });
+      users.forEach(user => delete user.password);
+      return users;
+    } catch (err) {
+      throw new InternalServerErrorException(err.message);
+    }
   }
 
   async findByEmail(email: string) {
@@ -52,6 +91,8 @@ export class UsersService {
     }
   }
 
+
+
   async update(id: number, updateUserDto: PartialUserDto) {
     return `This action updates a #${id} user`;
   }
@@ -59,4 +100,7 @@ export class UsersService {
   async remove(id: number) {
     return `This action removes a #${id} user`;
   }
+
+
+
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -8,7 +8,7 @@ import { CreateUserDto, UpdateUserDto } from './dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities';
 import { Repository } from 'typeorm';
-import { UUID, randomUUID } from 'crypto';
+import { UUID, randomUUID } from 'node:crypto';
 import { genSalt, hash } from 'bcrypt';
 
 @Injectable()
@@ -52,7 +52,7 @@ export class UsersService {
       }
       this.logger.log('Returned all users');
       return users;
-    } catch (err) 
+    } catch (err) {
       this.logger.error(err);
       throw err;
     }
@@ -69,7 +69,6 @@ export class UsersService {
       throw err;
     }
   }
-
 
   async findByEmail(email: string) {
     try {
@@ -116,7 +115,4 @@ export class UsersService {
       throw err;
     }
   }
-
-
-
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -10,6 +10,7 @@ import { User } from './entities';
 import { Repository } from 'typeorm';
 import { UUID, randomUUID } from 'node:crypto';
 import { genSalt, hash } from 'bcrypt';
+import { response } from 'express';
 
 @Injectable()
 export class UsersService {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -10,7 +10,6 @@ import { User } from './entities';
 import { Repository } from 'typeorm';
 import { UUID, randomUUID } from 'node:crypto';
 import { genSalt, hash } from 'bcrypt';
-import { response } from 'express';
 
 @Injectable()
 export class UsersService {
@@ -20,7 +19,7 @@ export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
-  ) { }
+  ) {}
 
   async create(createUserDto: CreateUserDto) {
     try {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -34,11 +34,11 @@ export class UsersService {
     }
   }
 
-  async findAll() {  //obtener todos los usuarios
-    const users = await this.usersRepository.find();
-    users.forEach((user) => delete user.password);
-    return users;
-  }
+
+
+
+
+
 
   async findOne(UUID: string): Promise<User> {
     try {
@@ -51,31 +51,20 @@ export class UsersService {
     }
   }
 
-  async findByQuery(query: { name?: string; email?: string }) {
+
+  async findAll(country?: string, name?: string, email?: string) {
+    let users: User[];
+    let query = {
+      ...(country && { country }),
+      ...(name && { name }),
+      ...(email && { email }),
+    };
     try {
-      const queryBuilder = this.usersRepository.createQueryBuilder('user');
-
-      if (query.name) {
-        queryBuilder.orWhere('user.name LIKE :name', { name: `%${query.name}%` });
+      if (Object.keys(query).length > 0) {
+        users = await this.usersRepository.findBy(query);
+      } else {
+        users = await this.usersRepository.find();
       }
-      if (query.email) {
-        queryBuilder.orWhere('user.email LIKE :email', { email: `%${query.email}%` });
-      }
-
-      const users = await queryBuilder.getMany();
-      users.forEach(user => delete user.password);
-      return users;
-    } catch (err) {
-      throw new InternalServerErrorException(err.message);
-    }
-  }
-
-  async findByCountry(country: string) {
-    try {
-      const users = await this.usersRepository.find({
-        where: { country }
-      });
-      users.forEach(user => delete user.password);
       return users;
     } catch (err) {
       throw new InternalServerErrorException(err.message);
@@ -92,7 +81,6 @@ export class UsersService {
       throw new InternalServerErrorException(err.message);
     }
   }
-
 
   async update(id: number, updateUserDto: PartialUserDto) {
     return `This action updates a #${id} user`;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -72,13 +72,16 @@ export class UsersService {
 
   async findByCountry(country: string) {
     try {
-      const users = await this.usersRepository.find({ where: { country } });
+      const users = await this.usersRepository.find({
+        where: { country }
+      });
       users.forEach(user => delete user.password);
       return users;
     } catch (err) {
       throw new InternalServerErrorException(err.message);
     }
   }
+
 
   async findByEmail(email: string) {
     try {
@@ -89,7 +92,6 @@ export class UsersService {
       throw new InternalServerErrorException(err.message);
     }
   }
-
 
 
   async update(id: number, updateUserDto: PartialUserDto) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -40,17 +40,16 @@ export class UsersService {
     return users;
   }
 
-  // async findOne(UUID: string ) {
-  //   try {
-  //     const user = await this.usersRepository.findOneBy({ id: UUID });
-  //     if (!user) throw new NotFoundException('User not found');
-  //     delete user.password;
-  //     return user;
-  //   } catch (err) {
-  //     throw new InternalServerErrorException(err.message);
-  //   }
-  // }
-
+  async findOne(UUID: string): Promise<User> {
+    try {
+      const user = await this.usersRepository.findOneBy({ id: UUID });
+      if (!user) throw new NotFoundException('User not found');
+      delete user.password;
+      return user;
+    } catch (err) {
+      throw new InternalServerErrorException(err.message);
+    }
+  }
 
   async findByQuery(query: { name?: string; email?: string }) {
     try {


### PR DESCRIPTION

### Add Admin Role Guard and User Fetching Endpoints
#### Features
- **Admin Role Guard**
  - Added a guard (`RolesGuard`) to restrict access to specific views to users with the Admin role.
  - Applied the guard to all routes that require administrative access.

- **User Fetching Endpoints**
  - Implemented various endpoints for fetching user data based on different criteria:
    - **GET `/users`**: Retrieve all registered users.
      - **User Story**: As an administrator, I want to see all registered users to know their details.
    - **GET `/users/country`**: Retrieve users by country.
      - **User Story**: As an administrator, I want to see all users from a specific country to understand where we have the most users.
    - **GET `/users/query`**: Retrieve users by name and email.
      - **User Story**: As an administrator, I want to search for all registered users by name or email to know their details.
    
  - Secured the endpoints using the `RolesGuard` to ensure only administrators can access them.

#### Implementation Details
- **Admin Role Guard**:
  - The `RolesGuard` has been implemented and integrated into the user fetching endpoints to restrict access to users with the Admin role.
- **Endpoints**:

  - **`@Get('/users')`**: Fetch all users (Admin only).
  - **`@Get('/users/country')`**: Fetch users by country (Admin only).
  - **`@Get('/users/query')`**: Fetch users by name and email (Admin only).

#### Testing
- Verified that only users with the Admin role can access protected views.
- Tested user fetching endpoints to ensure they return the correct data and handle edge cases appropriately.

#### Testing Endpoints
- **GET** `http://localhost:3000/users/`: Obtain all users (Admin only)
- **GET** `http://localhost:3000/users/query?email=testing@example.com`: Obtain users by email (Admin only)
- **GET** `http://localhost:3000/users/country?country=Chile`: Obtain users by country (Admin only)


