### PR TITLE
Fix update user

### DIFF
--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -2,5 +2,5 @@ import { OmitType, PartialType, PickType } from '@nestjs/mapped-types';
 import { CreateUserDto } from './';
 
 export class UpdateUserDto extends PartialType(
-  OmitType(CreateUserDto, ['rut', 'surname', 'password', 'country', 'role']),
+  OmitType(CreateUserDto, ['rut', 'password']),
 ) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -74,10 +74,15 @@ export class UsersController {
 
   @Patch(':id')
   @UseGuards(AuthGuard, RolesGuard)
-  @Roles(Role.ADMIN)
+  @Roles(Role.ADMIN, Role.USER)
   @UseInterceptors(ClassSerializerInterceptor)
-  update(@Param('id') id: UUID, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(id, updateUserDto);
+  update(
+    @Param('id') id: UUID,
+    @Body() updateUserDto: UpdateUserDto,
+    @Request() req: { request: ExpressRequest; user: PartialUserDto },
+  ) {
+    const { user } = req;
+    return this.usersService.update(id, updateUserDto, user);
   }
 
   @Delete(':id')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -152,9 +152,9 @@ export class UsersService {
   }
 
   async update(id: UUID, updateUserDto: UpdateUserDto, user: PartialUserDto) {
-    if (user.role !== 'admin') {
+    if (user.role === 'user' && updateUserDto.email) {
       throw new ForbiddenException(
-        'Forbidden resource, only admins can update user information.',
+        "Forbidden resource, you don't have permission to update this information.",
       );
     }
     try {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -138,12 +138,12 @@ export class UsersService {
       if (!isPasswordValid) {
         throw new ForbiddenException('Invalid credentials');
       }
-      if (updatePassword.newPassword) {
-        const salt = await genSalt(this.rounds);
-        const hashed = await hash(updatePassword.newPassword!, salt);
-        user.password = hashed;
+      if (!updatePassword.newPassword) {
+        throw new ForbiddenException('Must provide new password');
       }
-      this.usersRepository.merge({ ...user, ...updatePassword });
+      const salt = await genSalt(this.rounds);
+      const hashed = await hash(updatePassword.newPassword!, salt);
+      user.password = hashed;
       this.logger.log('Password successfully updated');
       return this.usersRepository.save(user);
     } catch (err) {
@@ -159,24 +159,12 @@ export class UsersService {
     }
     try {
       const user = await this.findOne(id);
-      if (updateUserDto.name) {
-        user.name = updateUserDto.name;
-      }
-      if ( updateUserDto.surname) {
-        user.surname = updateUserDto.surname;
-      }
-      if (updateUserDto.email) {
-        user.email = updateUserDto.email;
-      }
-      if ( updateUserDto.country) {
-        user.country = updateUserDto.country;
-      }
-      if (updateUserDto.role) {
-        user.role = updateUserDto.role;
-      }
-      this.usersRepository.merge({ ...user, ...updateUserDto });
+      const updatedUser = this.usersRepository.merge({
+        ...user,
+        ...updateUserDto,
+      });
       this.logger.log('User successfully updated');
-      return this.usersRepository.save(user);
+      return this.usersRepository.save(updatedUser);
     } catch (err) {
       throw err;
     }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -124,7 +124,7 @@ export class UsersService {
     updatePassword: UpdatePasswordDto,
     user: PartialUserDto,
   ) {
-    if (user.role !== 'admin' && user.id !== id) {
+    if (user.id !== id) {
       throw new ForbiddenException(
         'Forbidden resource, users can only update their own password',
       );
@@ -151,14 +151,28 @@ export class UsersService {
     }
   }
 
-  async update(id: UUID, updateUserDto: UpdateUserDto) {
+  async update(id: UUID, updateUserDto: UpdateUserDto, user: PartialUserDto) {
+    if (user.role !== 'admin') {
+      throw new ForbiddenException(
+        'Forbidden resource, only admins can update user information.',
+      );
+    }
     try {
       const user = await this.findOne(id);
       if (updateUserDto.name) {
         user.name = updateUserDto.name;
       }
+      if ( updateUserDto.surname) {
+        user.surname = updateUserDto.surname;
+      }
       if (updateUserDto.email) {
         user.email = updateUserDto.email;
+      }
+      if ( updateUserDto.country) {
+        user.country = updateUserDto.country;
+      }
+      if (updateUserDto.role) {
+        user.role = updateUserDto.role;
       }
       this.usersRepository.merge({ ...user, ...updateUserDto });
       this.logger.log('User successfully updated');

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -152,7 +152,7 @@ export class UsersService {
   }
 
   async update(id: UUID, updateUserDto: UpdateUserDto, user: PartialUserDto) {
-    if (user.role === 'user' && updateUserDto.email) {
+    if (user.role === 'user' && (updateUserDto.email || updateUserDto.role)) {
       throw new ForbiddenException(
         "Forbidden resource, you don't have permission to update this information.",
       );


### PR DESCRIPTION
Fix update user info.
- any user can update their own password using PATCH through the update password endpoint ('http://localhost:3000/me/:id'). The body must be in json and have a "password" and a "newPassword" attributes.
- any admin user can update their info (except password, email and rut) using PATCH method through the update endpoint ('http://localhost:3000/:id').
- any regular user can update only their name, surname and country using PATCH method through the update endpoint ('http://localhost:3000/:id'). 